### PR TITLE
chore: make watchDir configuration compatible to overseer

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -40,12 +40,12 @@
     }
   },
   "mountDir": "MOUNT_DIRECTORY",
+  "watchDirectory": "WATCH_DIRECTORY",
   "watcher": {
     "rootDirNestingLevel": {
       "__name": "ROOT_DIR_NESTING_LEVEL",
       "__format": "number"
     },
-    "watchDirectory": "WATCH_DIRECTORY",
     "watchOptions": {
       "minTriggerDepth": {
         "__name": "WATCH_MIN_TRIGGER_DEPTH",

--- a/config/default.json
+++ b/config/default.json
@@ -26,8 +26,8 @@
     }
   },
   "mountDir": "/layerSources",
+  "watchDirectory": "watch",
   "watcher": {
-    "watchDirectory": "watch",
     "rootDirNestingLevel": 1,
     "watchOptions": {
       "minTriggerDepth": 1,

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
   LOG_LEVEL: {{ .Values.env.logLevel | quote }}
   LOG_PRETTY_PRINT_ENABLED: {{ .Values.env.logPrettyPrintEnabled | quote }}
   ROOT_DIR_NESTING_LEVEL: {{ .Values.env.watcher.rootDirNestingLevel | quote }}
-  WATCH_DIRECTORY: {{ .Values.env.watcher.directory | quote }}
+  WATCH_DIRECTORY: {{ .Values.rasterCommon.ingestion.watchDirectoryOptions.directory | quote }}
   WATCH_MIN_TRIGGER_DEPTH: {{ .Values.env.watcher.options.minTriggerDepth | quote }}
   WATCH_MAX_TRIGGER_DEPTH: {{ .Values.env.watcher.options.maxWatchDepth | quote }}
   WATCH_INTERVAL: {{ .Values.env.watcher.options.interval | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,7 +31,10 @@ rasterCommon:
     secretName: ''
     path: '/usr/local/share/ca-certificates'
     key: 'ca.crt'
-
+  ingestion:
+    watchDirectoryOptions:
+      directory: 'watch'
+      
 enabled: true
 environment: development
 replicaCount: 1

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -23,7 +23,7 @@ export const registerExternalValues = (options?: RegisterOptions): DependencyCon
   tracing.start();
   const tracer = trace.getTracer(SERVICE_NAME);
   const mountDir = config.get<string>('mountDir');
-  const watchDir = config.get<string>('watcher.watchDirectory');
+  const watchDir = config.get<string>('watchDirectory');
   const relativeWatchDirPath = join(mountDir, watchDir);
 
   const dependencies: InjectionObject<unknown>[] = [

--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -74,7 +74,7 @@ export class Watcher {
 
   private loadWatchOptions(config: IConfig): void {
     const mountDir = config.get<string>('mountDir');
-    const watchDir = config.get<string>('watcher.watchDirectory');
+    const watchDir = config.get<string>('watchDirectory');
     this.watchTarget = joinPath(mountDir, watchDir);
     const options = config.get<WatchOptions>('watcher.watchOptions');
     this.minTriggerDepth = toInteger(options.minTriggerDepth);

--- a/tests/mocks/config.ts
+++ b/tests/mocks/config.ts
@@ -33,8 +33,8 @@ const registerDefaultConfig = (): void => {
       port: '8080',
     },
     mountDir: '/layerSources',
+    watchDirectory: 'watch',
     watcher: {
-      watchDirectory: 'watch',
       rootDirNestingLevel: 1,
       watchOptions: {
         minTriggerDepth: 1,

--- a/tests/unit/watcher/watcher.spec.ts
+++ b/tests/unit/watcher/watcher.spec.ts
@@ -16,7 +16,7 @@ const realTimeout = setTimeout;
 describe('watcher', () => {
   beforeEach(() => {
     configData['mountDir'] = '/mountDir';
-    configData['watcher.watchDirectory'] = 'watch';
+    configData['watchDirectory'] = 'watch';
     configData['watcher.watchOptions'] = {
       minTriggerDepth: 1,
       maxWatchDepth: 2,


### PR DESCRIPTION
Updating agent configuration and helm to be suitable and generic with overseer and raster-helm

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   |✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

