### PR TITLE
feat: adding compatibility with new mc-models including transparency (MAPCO-2580)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@map-colonies/error-types": "^1.1.0",
         "@map-colonies/express-access-log-middleware": "^1.0.0",
         "@map-colonies/js-logger": "^0.0.4",
-        "@map-colonies/mc-model-types": "^12.1.0",
+        "@map-colonies/mc-model-types": "^14.0.0",
         "@map-colonies/mc-utils": "^1.4.4",
         "@map-colonies/openapi-express-viewer": "^2.0.1",
         "@map-colonies/read-pkg": "0.0.1",
@@ -3165,9 +3165,9 @@
       }
     },
     "node_modules/@map-colonies/mc-model-types": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-12.1.0.tgz",
-      "integrity": "sha512-3QpFIMHHaJwcZO/9i7KetVxZLOMiMqZ2mgagW0457sGEmAvsufrErAkvQ1JsFkeIFdDqVXGXAM9OvCKCDlv5xA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"
@@ -20389,9 +20389,9 @@
       }
     },
     "@map-colonies/mc-model-types": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-12.1.0.tgz",
-      "integrity": "sha512-3QpFIMHHaJwcZO/9i7KetVxZLOMiMqZ2mgagW0457sGEmAvsufrErAkvQ1JsFkeIFdDqVXGXAM9OvCKCDlv5xA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@map-colonies/error-types": "^1.1.0",
     "@map-colonies/express-access-log-middleware": "^1.0.0",
     "@map-colonies/js-logger": "^0.0.4",
-    "@map-colonies/mc-model-types": "^12.1.0",
+    "@map-colonies/mc-model-types": "^14.0.0",
     "@map-colonies/mc-utils": "^1.4.4",
     "@map-colonies/openapi-express-viewer": "^2.0.1",
     "@map-colonies/read-pkg": "0.0.1",

--- a/src/layerCreator/models/metadataMapper.ts
+++ b/src/layerCreator/models/metadataMapper.ts
@@ -1,4 +1,4 @@
-import { IPropSHPMapping, LayerMetadata, DataFileType, TsTypes } from '@map-colonies/mc-model-types';
+import { IPropSHPMapping, LayerMetadata, DataFileType, TsTypes, Transparency } from '@map-colonies/mc-model-types';
 import { injectable } from 'tsyringe';
 import { FeatureCollection, GeoJSON, Polygon } from 'geojson';
 import { get as readProp, toNumber, isNil } from 'lodash';
@@ -59,6 +59,8 @@ export class MetadataMapper {
       const value = readProp(sources[map.dataFile], map.valuePath) as unknown;
       metadata[map.prop] = this.castValue(value, type);
     });
+    // todo - should consider on future make it dynamic if it will support opaque too
+    metadata.transparency = Transparency.TRANSPARENT;
   }
 
   private parseIdentifiers(metadata: LayerMetadata, metadataGeoJson: GeoJSON): void {

--- a/tests/mockData/ingestionParams.ts
+++ b/tests/mockData/ingestionParams.ts
@@ -1,5 +1,7 @@
+import { Transparency } from '@map-colonies/mc-model-types';
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
+
 export const ingestionParams = {
   originDirectory: 'test',
   fileNames: [
@@ -51,6 +53,7 @@ export const ingestionParams = {
     srsId: undefined,
     srsName: undefined,
     type: 'RECORD_RASTER',
+    transparency: Transparency.TRANSPARENT,
     layerPolygonParts: {
       type: 'FeatureCollection',
       features: [

--- a/tests/mockData/layerMetadata.ts
+++ b/tests/mockData/layerMetadata.ts
@@ -71,4 +71,5 @@ export const metadata = {
   },
   includedInBests: undefined,
   productBoundingBox: undefined,
+  transparency: 'TRANSPARENT',
 };


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

* bumping mc-models from 12.*.* to 14.0.0
* adding transparency as ingestionParams